### PR TITLE
Fix for ie11

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,8 +43,8 @@
   ],
   "dependencies": {
     "long": "^4.0.0",
-    "lru-cache": "^4.1.3",
     "pako": "1.0.6",
+    "quick-lru": "^2.0.0",
     "util.promisify": "^1.0.0"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -42,10 +42,10 @@
     "genomics"
   ],
   "dependencies": {
+    "es6-promisify": "^6.0.1",
     "long": "^4.0.0",
     "pako": "1.0.6",
-    "quick-lru": "^2.0.0",
-    "util.promisify": "^1.0.0"
+    "quick-lru": "^2.0.0"
   },
   "devDependencies": {
     "babel-cli": "^6.26.0",

--- a/src/localFile.js
+++ b/src/localFile.js
@@ -1,4 +1,4 @@
-const promisify = require('util.promisify')
+const {promisify} = require('es6-promisify')
 
 // don't load fs native module if running in webpacked code
 const fs = typeof __webpack_require__ !== 'function' ? require('fs') : null // eslint-disable-line camelcase

--- a/src/tabixIndexedFile.js
+++ b/src/tabixIndexedFile.js
@@ -1,5 +1,5 @@
 const { unzip, unzipChunk } = require('./unzip')
-const LRU = require('lru-cache')
+const LRU = require('quick-lru')
 
 const LocalFile = require('./localFile')
 const TBI = require('./tbi')
@@ -72,11 +72,12 @@ class TabixIndexedFile {
     this.chunkSizeLimit = chunkSizeLimit
     this.yieldLimit = yieldLimit
     this.renameRefSeqCallback = renameRefSeqs
-    this.chunkCache = LRU({
-      max: Math.floor(chunkCacheSize / (1 << 16)),
-      length: () => 1,
+    this.chunkCache = new LRU({
+      maxSize: Math.floor(chunkCacheSize / (1 << 16))
     })
-    this.blockCache = LRU({ max: Math.floor(blockCacheSize / (1 << 16)) })
+    this.blockCache = new LRU({
+      maxSize: Math.floor(blockCacheSize / (1 << 16))
+    })
   }
 
   /**

--- a/yarn.lock
+++ b/yarn.lock
@@ -1985,6 +1985,11 @@ es-to-primitive@^1.1.1:
     is-date-object "^1.0.1"
     is-symbol "^1.0.1"
 
+es6-promisify@^6.0.1:
+  version "6.0.1"
+  resolved "https://registry.yarnpkg.com/es6-promisify/-/es6-promisify-6.0.1.tgz#6edaa45f3bd570ffe08febce66f7116be4b1cdb6"
+  integrity sha512-J3ZkwbEnnO+fGAKrjVpeUAnZshAdfZvbhQpqfIH9kSAspReRC4nJnu8ewm55b4y9ElyeuhCTzJD0XiH8Tsbhlw==
+
 escape-string-regexp@1.0.5, escape-string-regexp@^1.0.2, escape-string-regexp@^1.0.5:
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz#1b61c0562190a8dff6ae3bb2cf0200ca130b86d4"

--- a/yarn.lock
+++ b/yarn.lock
@@ -92,16 +92,6 @@
     lodash "^4.2.0"
     to-fast-properties "^2.0.0"
 
-"@gmod/bgzf-filehandle@^1.2.1":
-  version "1.2.1"
-  resolved "https://registry.yarnpkg.com/@gmod/bgzf-filehandle/-/bgzf-filehandle-1.2.1.tgz#88368b3c6735a1d7c000e157af110c7668e88d4a"
-  dependencies:
-    binary-parser "^1.3.2"
-    fs-extra "^7.0.0"
-    long "^4.0.0"
-    pako "^1.0.6"
-    util.promisify "^1.0.0"
-
 "@sindresorhus/is@^0.7.0":
   version "0.7.0"
   resolved "https://registry.yarnpkg.com/@sindresorhus/is/-/is-0.7.0.tgz#9a06f4f137ee84d7df0460c1fdb1135ffa6c50fd"
@@ -1166,10 +1156,6 @@ bcrypt-pbkdf@^1.0.0:
 binary-extensions@^1.0.0:
   version "1.11.0"
   resolved "https://registry.yarnpkg.com/binary-extensions/-/binary-extensions-1.11.0.tgz#46aa1751fb6a2f93ee5e689bb1087d4b14c6c205"
-
-binary-parser@^1.3.2:
-  version "1.3.2"
-  resolved "https://registry.yarnpkg.com/binary-parser/-/binary-parser-1.3.2.tgz#5bd04f948ada1a6d78c528762308a9a335d63db9"
 
 body@^5.1.0:
   version "5.1.0"
@@ -2434,14 +2420,6 @@ fs-copy-file-sync@^1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/fs-copy-file-sync/-/fs-copy-file-sync-1.1.1.tgz#11bf32c096c10d126e5f6b36d06eece776062918"
 
-fs-extra@^7.0.0:
-  version "7.0.0"
-  resolved "https://registry.yarnpkg.com/fs-extra/-/fs-extra-7.0.0.tgz#8cc3f47ce07ef7b3593a11b9fb245f7e34c041d6"
-  dependencies:
-    graceful-fs "^4.1.2"
-    jsonfile "^4.0.0"
-    universalify "^0.1.0"
-
 fs-minipass@^1.2.5:
   version "1.2.5"
   resolved "https://registry.yarnpkg.com/fs-minipass/-/fs-minipass-1.2.5.tgz#06c277218454ec288df77ada54a03b8702aacb9d"
@@ -3701,12 +3679,6 @@ json5@^0.5.1:
   version "0.5.1"
   resolved "https://registry.yarnpkg.com/json5/-/json5-0.5.1.tgz#1eade7acc012034ad84e2396767ead9fa5495821"
 
-jsonfile@^4.0.0:
-  version "4.0.0"
-  resolved "https://registry.yarnpkg.com/jsonfile/-/jsonfile-4.0.0.tgz#8771aae0799b64076b76640fca058f9c10e33ecb"
-  optionalDependencies:
-    graceful-fs "^4.1.6"
-
 jsonify@~0.0.0:
   version "0.0.0"
   resolved "https://registry.yarnpkg.com/jsonify/-/jsonify-0.0.0.tgz#2c74b6ee41d93ca51b7b5aaee8f503631d252a73"
@@ -3881,7 +3853,7 @@ lowercase-keys@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/lowercase-keys/-/lowercase-keys-1.0.1.tgz#6f9e30b47084d971a7c820ff15a6c5167b74c26f"
 
-lru-cache@^4.0.1, lru-cache@^4.1.3:
+lru-cache@^4.0.1:
   version "4.1.3"
   resolved "https://registry.yarnpkg.com/lru-cache/-/lru-cache-4.1.3.tgz#a1175cf3496dfc8436c156c334b4955992bce69c"
   dependencies:
@@ -4496,9 +4468,10 @@ package-json@^4.0.0:
     registry-url "^3.0.3"
     semver "^5.1.0"
 
-pako@^1.0.6:
+pako@1.0.6:
   version "1.0.6"
   resolved "https://registry.yarnpkg.com/pako/-/pako-1.0.6.tgz#0101211baa70c4bca4a0f63f2206e97b7dfaf258"
+  integrity sha512-lQe48YPsMJAig+yngZ87Lus+NF+3mtu7DVOBu6b/gHO1YpKwIj5AWjZ/TOS7i46HD/UixzWb1zeWDZfGZ3iYcg==
 
 parents@^1.0.0:
   version "1.0.1"
@@ -4803,6 +4776,11 @@ query-string@^5.0.1:
     decode-uri-component "^0.2.0"
     object-assign "^4.1.0"
     strict-uri-encode "^1.0.0"
+
+quick-lru@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/quick-lru/-/quick-lru-2.0.0.tgz#32b017b28d1784631c8ab0a1ed2978e094dbe181"
+  integrity sha512-DqOtZziv7lDjEyuqyVQacRciAwMCEjTNrLYCHYEIIgjcE/tLEpBF82hiDIwCjRnEL9/hY2GJxA0T8ZvYvVVSSA==
 
 randomatic@^3.0.0:
   version "3.0.0"
@@ -5979,10 +5957,6 @@ unist-util-visit@^1.0.0, unist-util-visit@^1.1.0, unist-util-visit@^1.3.0:
   resolved "https://registry.yarnpkg.com/unist-util-visit/-/unist-util-visit-1.4.0.tgz#1cb763647186dc26f5e1df5db6bd1e48b3cc2fb1"
   dependencies:
     unist-util-visit-parents "^2.0.0"
-
-universalify@^0.1.0:
-  version "0.1.2"
-  resolved "https://registry.yarnpkg.com/universalify/-/universalify-0.1.2.tgz#b646f69be3942dabcecc9d6639c80dc105efaa66"
 
 unset-value@^1.0.0:
   version "1.0.0"


### PR DESCRIPTION
This changes to use quick-lru which aids IE11 compatibility because lru-cache uses Object.defineProperty on length which seems un-babel-ifiable

The util.promisify also can end up doing Object.defineProperty on the length property too so es6-promisify is used