### PR TITLE
Buffer iteration

### DIFF
--- a/src/tabixIndexedFile.js
+++ b/src/tabixIndexedFile.js
@@ -112,21 +112,20 @@ class TabixIndexedFile {
     }
 
     // now go through each chunk and parse and filter the lines out of it
-    await Promise.all(
-      chunks.map((chunk, chunkNum) => {
-        const currentLineStart = chunks[chunkNum].minv.dataPosition
-        const fileOffset = chunks[chunkNum].minv.blockPosition * 2 ** 16
-        return this.readChunk(chunks[chunkNum], {
-          refName,
-          start,
-          end,
-          metadata,
-          fileOffset,
-          currentLineStart,
-          lineCallback,
-        })
-      }),
-    )
+    for (let chunkNum = 0; chunkNum < chunks.length; chunkNum += 1) {
+      const chunk = chunks[chunkNum]
+      const currentLineStart = chunk.minv.dataPosition
+      const fileOffset = chunk.minv.blockPosition * 2 ** 16
+      await this.readChunk(chunk, {
+        refName,
+        start,
+        end,
+        metadata,
+        fileOffset,
+        currentLineStart,
+        lineCallback,
+      })
+    }
   }
 
   async getMetadata() {


### PR DESCRIPTION
This enables iteration over a inflated bgzip data to breakup on instances of '\n'. I didn't get split buffer passing tests so I made this. This also gets rid of block merges in the indexes which resulted in very large indexes in some cases and then made large unzip calls. I think this helps enable #24 and helps towards fixing #10 

I haven't really assessed performance but at least with the removal of the block merges it is now possible to query larger regions that before I think basically caused issues