### PR TITLE
Use unmerged bgzip blocks in iteration

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,7 +46,8 @@
     "generic-filehandle": "^1.0.9",
     "long": "^4.0.0",
     "pako": "1.0.10",
-    "quick-lru": "^2.0.0"
+    "quick-lru": "^2.0.0",
+    "text-encoding": "^0.7.0"
   },
   "devDependencies": {
     "@babel/cli": "^7.2.3",

--- a/src/csi.js
+++ b/src/csi.js
@@ -288,18 +288,6 @@ class CSI {
     for (let i = 1; i < numOffsets; i += 1)
       if (off[i - 1].maxv.compareTo(off[i].minv) >= 0)
         off[i - 1].maxv = off[i].minv
-    // merge adjacent blocks
-    l = 0
-    for (let i = 1; i < numOffsets; i += 1) {
-      if (off[l].maxv.blockPosition === off[i].minv.blockPosition)
-        off[l].maxv = off[i].maxv
-      else {
-        l += 1
-        off[l].minv = off[i].minv
-        off[l].maxv = off[i].maxv
-      }
-    }
-    numOffsets = l + 1
 
     return off.slice(0, numOffsets)
   }

--- a/src/tabixIndexedFile.js
+++ b/src/tabixIndexedFile.js
@@ -1,3 +1,5 @@
+import { TextDecoder } from 'text-encoding'
+
 const LRU = require('quick-lru')
 const { LocalFile } = require('generic-filehandle')
 const { unzip, unzipChunk } = require('./unzip')
@@ -387,8 +389,9 @@ class TabixIndexedFile {
       } catch (e) {
         throw new Error(`error decompressing chunk ${chunk.toString()}`)
       }
+      const d = new TextDecoder()
 
-      const lines = uncompressed.toString('utf8').split('\n')
+      const lines = d.decode(uncompressed).split('\n')
 
       // remove the last line, since it will be either empty or partial
       lines.pop()

--- a/src/tabixIndexedFile.js
+++ b/src/tabixIndexedFile.js
@@ -14,6 +14,7 @@ function timeout(time) {
 }
 
 // we use text decoder if in browser or webworker in browser
+// eslint-disable-next-line no-restricted-globals
 const isBrowser = typeof window !== 'undefined' || typeof self !== 'undefined'
 
 class TabixIndexedFile {

--- a/src/tabixIndexedFile.js
+++ b/src/tabixIndexedFile.js
@@ -13,6 +13,9 @@ function timeout(time) {
   })
 }
 
+// we use text decoder if in browser or webworker in browser
+const isBrowser = typeof window !== 'undefined' || typeof self !== 'undefined'
+
 class TabixIndexedFile {
   /**
    * @param {object} args
@@ -390,8 +393,10 @@ class TabixIndexedFile {
         throw new Error(`error decompressing chunk ${chunk.toString()}`)
       }
       const d = new TextDecoder()
-
-      const lines = d.decode(uncompressed).split('\n')
+      const lines = (isBrowser
+        ? d.decode(uncompressed)
+        : uncompressed.toString()
+      ).split('\n')
 
       // remove the last line, since it will be either empty or partial
       lines.pop()

--- a/src/tbi.js
+++ b/src/tbi.js
@@ -268,18 +268,6 @@ class TabixIndex {
     for (let i = 1; i < numOffsets; i += 1)
       if (off[i - 1].maxv.compareTo(off[i].minv) >= 0)
         off[i - 1].maxv = off[i].minv
-    // merge adjacent blocks
-    l = 0
-    for (let i = 1; i < numOffsets; i += 1) {
-      if (off[l].maxv.blockPosition === off[i].minv.blockPosition)
-        off[l].maxv = off[i].maxv
-      else {
-        l += 1
-        off[l].minv = off[i].minv
-        off[l].maxv = off[i].maxv
-      }
-    }
-    numOffsets = l + 1
 
     return off.slice(0, numOffsets)
   }

--- a/src/unzip.js
+++ b/src/unzip.js
@@ -49,9 +49,17 @@ function unzipChunk(inputData, chunk) {
     }
     if (fileStartingOffset + pos >= chunk.maxv.blockPosition) {
       // this is the last chunk, trim it and stop decompressing
+      // note if it is the same block is minv it subtracts that already
+      // trimmed part of the slice length
+
       decompressedBlocks[decompressedBlocks.length - 1] = decompressedBlocks[
         decompressedBlocks.length - 1
-      ].slice(0, chunk.maxv.dataPosition + 1)
+      ].slice(
+        0,
+        chunk.minv.blockPosition === chunk.maxv.blockPosition
+          ? chunk.maxv.dataPosition - chunk.minv.dataPosition + 1
+          : chunk.maxv.blockPosition + 1,
+      )
       break
     }
     // if we are not at the last chunk and there is no more input available,

--- a/test/csi.test.js
+++ b/test/csi.test.js
@@ -45,7 +45,7 @@ describe('csi index', () => {
     let blocks = await ti.blocksForRange('1', 1, 4000)
     expect(blocks.length).toEqual(0)
     blocks = await ti.blocksForRange('1', 0, 2000046092)
-    expect(blocks.length).toEqual(1)
+    expect(blocks.length).toEqual(4)
     expect(blocks[0].minv.blockPosition).toEqual(0)
     expect(blocks[0].minv.dataPosition).toEqual(2560)
     // console.log( blocks );

--- a/yarn.lock
+++ b/yarn.lock
@@ -5814,6 +5814,11 @@ test-exclude@^5.0.0:
     read-pkg-up "^4.0.0"
     require-main-filename "^1.0.1"
 
+text-encoding@^0.7.0:
+  version "0.7.0"
+  resolved "https://registry.yarnpkg.com/text-encoding/-/text-encoding-0.7.0.tgz#f895e836e45990624086601798ea98e8f36ee643"
+  integrity sha512-oJQ3f1hrOnbRLOcwKz0Liq2IcrvDeZRHXhd9RgLrsT+DjWY/nty1Hi7v3dtkaEYbPYe0mUoOfzRrMwfXXwgPUA==
+
 text-table@^0.2.0:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/text-table/-/text-table-0.2.0.tgz#7f5ee823ae805207c00af2df4a84ec3fcfa570b4"


### PR DESCRIPTION
This now makes chunks not get merged in the index, resulting in small chunk processing, and you can do arbitrarily large requests against the genome

This is based onto #25 




