### PR TITLE
Modify the checkLine to operation on slice of buffer

### DIFF
--- a/src/csi.js
+++ b/src/csi.js
@@ -288,18 +288,6 @@ class CSI {
     for (let i = 1; i < numOffsets; i += 1)
       if (off[i - 1].maxv.compareTo(off[i].minv) >= 0)
         off[i - 1].maxv = off[i].minv
-    // merge adjacent blocks
-    l = 0
-    for (let i = 1; i < numOffsets; i += 1) {
-      if (off[l].maxv.blockPosition === off[i].minv.blockPosition)
-        off[l].maxv = off[i].maxv
-      else {
-        l += 1
-        off[l].minv = off[i].minv
-        off[l].maxv = off[i].maxv
-      }
-    }
-    numOffsets = l + 1
 
     return off.slice(0, numOffsets)
   }

--- a/src/tabixIndexedFile.js
+++ b/src/tabixIndexedFile.js
@@ -112,21 +112,20 @@ class TabixIndexedFile {
     }
 
     // now go through each chunk and parse and filter the lines out of it
-    await Promise.all(
-      chunks.map((chunk, chunkNum) => {
-        const currentLineStart = chunks[chunkNum].minv.dataPosition
-        const fileOffset = chunks[chunkNum].minv.blockPosition * 2 ** 16
-        return this.readChunk(chunks[chunkNum], {
-          refName,
-          start,
-          end,
-          metadata,
-          fileOffset,
-          currentLineStart,
-          lineCallback,
-        })
-      }),
-    )
+    for (let chunkNum = 0; chunkNum < chunks.length; chunkNum += 1) {
+      const chunk = chunks[chunkNum]
+      const currentLineStart = chunk.minv.dataPosition
+      const fileOffset = chunk.minv.blockPosition * 2 ** 16
+      await this.readChunk(chunk, {
+        refName,
+        start,
+        end,
+        metadata,
+        fileOffset,
+        currentLineStart,
+        lineCallback,
+      })
+    }
   }
 
   async getMetadata() {

--- a/src/tbi.js
+++ b/src/tbi.js
@@ -268,18 +268,6 @@ class TabixIndex {
     for (let i = 1; i < numOffsets; i += 1)
       if (off[i - 1].maxv.compareTo(off[i].minv) >= 0)
         off[i - 1].maxv = off[i].minv
-    // merge adjacent blocks
-    l = 0
-    for (let i = 1; i < numOffsets; i += 1) {
-      if (off[l].maxv.blockPosition === off[i].minv.blockPosition)
-        off[l].maxv = off[i].maxv
-      else {
-        l += 1
-        off[l].minv = off[i].minv
-        off[l].maxv = off[i].maxv
-      }
-    }
-    numOffsets = l + 1
 
     return off.slice(0, numOffsets)
   }

--- a/src/unzip.js
+++ b/src/unzip.js
@@ -49,9 +49,17 @@ function unzipChunk(inputData, chunk) {
     }
     if (fileStartingOffset + pos >= chunk.maxv.blockPosition) {
       // this is the last chunk, trim it and stop decompressing
+      // note if it is the same block is minv it subtracts that already
+      // trimmed part of the slice length
+
       decompressedBlocks[decompressedBlocks.length - 1] = decompressedBlocks[
         decompressedBlocks.length - 1
-      ].slice(0, chunk.maxv.dataPosition + 1)
+      ].slice(
+        0,
+        chunk.minv.blockPosition === chunk.maxv.blockPosition
+          ? chunk.maxv.dataPosition - chunk.minv.dataPosition + 1
+          : chunk.maxv.blockPosition + 1,
+      )
       break
     }
     // if we are not at the last chunk and there is no more input available,

--- a/test/csi.test.js
+++ b/test/csi.test.js
@@ -45,7 +45,7 @@ describe('csi index', () => {
     let blocks = await ti.blocksForRange('1', 1, 4000)
     expect(blocks.length).toEqual(0)
     blocks = await ti.blocksForRange('1', 0, 2000046092)
-    expect(blocks.length).toEqual(1)
+    expect(blocks.length).toEqual(4)
     expect(blocks[0].minv.blockPosition).toEqual(0)
     expect(blocks[0].minv.dataPosition).toEqual(2560)
     // console.log( blocks );


### PR DESCRIPTION
This modifies the checkLine function to operate directly on the buffer, which delays conversion to utf8 and makes things faster

Based off of #27 for clarity at least for now