### PR TITLE
Fix small issue with the bgzf processing

### DIFF
--- a/src/unzip.js
+++ b/src/unzip.js
@@ -58,7 +58,7 @@ function unzipChunk(inputData, chunk) {
         0,
         chunk.minv.blockPosition === chunk.maxv.blockPosition
           ? chunk.maxv.dataPosition - chunk.minv.dataPosition + 1
-          : chunk.maxv.blockPosition + 1,
+          : chunk.maxv.dataPosition + 1,
       )
       break
     }


### PR DESCRIPTION
This adjusts the clipping on the chunk.maxv in the unzipChunk. In bam-js, the symptom of being without this change was that duplicate features could be returned