### PR TITLE
Add aborting

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,12 @@ const remoteTbiIndexed = new TabixIndexedFile({
 // is structured as
 const lines = []
 await tbiIndexed.getLines('ctgA',200,300, (line, fileOffset) => lines.push(line))
+// alternative API usage
+const aborter = new AbortController()
+await tbiIndexed.getLines('ctgA',200,300, {
+  lineCallback: (line, fileOffset) => lines.push(line),
+  signal: aborter.signal// an AbortController signal
+})
 // lines is now an array of strings, which are data lines.
 // commented (meta) lines are skipped.
 // line strings do not include any trailing whitespace characters.

--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
   ],
   "dependencies": {
     "@babel/runtime-corejs2": "^7.3.1",
+    "abortable-promise-cache": "^1.0.1",
     "es6-promisify": "^6.0.1",
     "generic-filehandle": "^2.0.0",
     "long": "^4.0.0",

--- a/src/tabixIndexedFile.js
+++ b/src/tabixIndexedFile.js
@@ -382,7 +382,6 @@ class TabixIndexedFile {
    * @returns {Promise} for a string chunk of the file
    */
   async readChunk(chunk, signal) {
-    console.log(signal)
     // fetch the uncompressed data, uncompress carefully a block at a time,
     // and stop when done
 

--- a/test/tabixindexedfile.test.js
+++ b/test/tabixindexedfile.test.js
@@ -327,6 +327,16 @@ describe('tabix file', () => {
     expect(lines.length).toEqual(1)
   })
 
+  it('can fetch a CNV with length defined by END in INFO field using the opts.lineCallback', async () => {
+    const f = new TabixIndexedFile({
+      path: require.resolve('./data/CNVtest.vcf.gz'),
+    })
+
+    const lines = new RecordCollector()
+    await f.getLines('22', 16063470, 16063480, { lineCallback: lines.callback })
+    expect(lines.length).toEqual(1)
+  })
+
   it('can get the correct fileOffset', async () => {
     const uncompressedVcf = new LocalFile(
       require.resolve('./data/OffsetTest.vcf'),

--- a/yarn.lock
+++ b/yarn.lock
@@ -1207,6 +1207,19 @@ abbrev@1:
   resolved "https://registry.yarnpkg.com/abbrev/-/abbrev-1.1.1.tgz#f8f2c887ad10bf67f634f005b6987fed3179aac8"
   integrity sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==
 
+abortable-promise-cache@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/abortable-promise-cache/-/abortable-promise-cache-1.0.1.tgz#68638de7806444e0fc3f3c2c5d53b81fad1c4466"
+  integrity sha512-Iu27BBSRe6jPrNhf5SjCyxJ0yb8fJ63H3CRoEVD+sJ2AvJsXppY5PVMvpFlB4si8K2cTFgjSgYNTELjm9ofwTQ==
+  dependencies:
+    abortcontroller-polyfill "^1.2.9"
+    babel-runtime "^6.26.0"
+
+abortcontroller-polyfill@^1.2.9:
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/abortcontroller-polyfill/-/abortcontroller-polyfill-1.3.0.tgz#de69af32ae926c210b7efbcc29bf644ee4838b00"
+  integrity sha512-lbWQgf+eRvku3va8poBlDBO12FigTQr9Zb7NIjXrePrhxWVKdCP2wbDl1tLDaYa18PWTom3UEWwdH13S46I+yA==
+
 acorn-globals@^4.1.0:
   version "4.3.2"
   resolved "https://registry.yarnpkg.com/acorn-globals/-/acorn-globals-4.3.2.tgz#4e2c2313a597fd589720395f6354b41cd5ec8006"
@@ -1477,6 +1490,14 @@ babel-preset-jest@^24.6.0:
   dependencies:
     "@babel/plugin-syntax-object-rest-spread" "^7.0.0"
     babel-plugin-jest-hoist "^24.6.0"
+
+babel-runtime@^6.26.0:
+  version "6.26.0"
+  resolved "https://registry.yarnpkg.com/babel-runtime/-/babel-runtime-6.26.0.tgz#965c7058668e82b55d7bfe04ff2337bc8b5647fe"
+  integrity sha1-llxwWGaOgrVde/4E/yM3vItWR/4=
+  dependencies:
+    core-js "^2.4.0"
+    regenerator-runtime "^0.11.0"
 
 babelify@^10.0.0:
   version "10.0.0"
@@ -2042,7 +2063,7 @@ core-js-pure@3.1.4:
   resolved "https://registry.yarnpkg.com/core-js-pure/-/core-js-pure-3.1.4.tgz#5fa17dc77002a169a3566cc48dc774d2e13e3769"
   integrity sha512-uJ4Z7iPNwiu1foygbcZYJsJs1jiXrTTCvxfLDXNhI/I+NHbSIEyr548y4fcsCEyWY0XgfAG/qqaunJ1SThHenA==
 
-core-js@^2.6.5:
+core-js@^2.4.0, core-js@^2.6.5:
   version "2.6.9"
   resolved "https://registry.yarnpkg.com/core-js/-/core-js-2.6.9.tgz#6b4b214620c834152e179323727fc19741b084f2"
   integrity sha512-HOpZf6eXmnl7la+cUdMnLvUxKNqLUzJvgIziQ0DiF3JwSImNphIqdGqzj6hIKyX04MmV0poclQ7+wjWvxQyR2A==
@@ -5812,6 +5833,11 @@ regenerate@^1.4.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/regenerate/-/regenerate-1.4.0.tgz#4a856ec4b56e4077c557589cae85e7a4c8869a11"
   integrity sha512-1G6jJVDWrt0rK99kBjvEtziZNCICAuvIPkSiUFIQxVP06RCVpq3dmDo2oi6ABpYaDYaTRr67BEhL8r1wgEZZKg==
+
+regenerator-runtime@^0.11.0:
+  version "0.11.1"
+  resolved "https://registry.yarnpkg.com/regenerator-runtime/-/regenerator-runtime-0.11.1.tgz#be05ad7f9bf7d22e056f9726cee5017fbf19e2e9"
+  integrity sha512-MguG95oij0fC3QV3URf4V2SDYGJhJnJGqvIIgdECeODCT98wSWDAJ94SSuVpYQUoTcGUIL6L4yNB7j1DFFHSBg==
 
 regenerator-runtime@^0.13.2:
   version "0.13.2"


### PR DESCRIPTION
This uses abortable-promise-cache to add aborting to readchunk requests. This is similar to how bam-js currently accomplishes it

It changes the getLines callback to optionally accept an options argument in place of the lineCallback, which can include a lineCallback propery and a signal property