### PR TITLE
Add open-ended getLines query

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ const headerBuffer = await tbiIndexed.getHeaderBuffer()
 ```
 
 You may also use e.g. `tbiIndexed.getLines('ctgA', 200, undefined, lineCallback)`
-to get all lines staring at 200 and going to the end of ctgA.
+to get all lines starting at 200 and going to the end of ctgA.
 
 ## Academic Use
 

--- a/README.md
+++ b/README.md
@@ -54,6 +54,9 @@ const headerText = await tbiIndexed.getHeader()
 const headerBuffer = await tbiIndexed.getHeaderBuffer()
 ```
 
+You may also use e.g. `tbiIndexed.getLines('ctgA', 200, undefined, lineCallback)`
+to get all lines staring at 200 and going to the end of ctgA.
+
 ## Academic Use
 
 This package was written with funding from the [NHGRI](http://genome.gov) as part of the [JBrowse](http://jbrowse.org) project. If you use it in an academic project that you publish, please cite the most recent JBrowse paper, which will be linked from [jbrowse.org](http://jbrowse.org).

--- a/src/csi.js
+++ b/src/csi.js
@@ -85,9 +85,11 @@ class CSI {
       coordinateType,
       skipLines,
       refIdToName,
-      maxBlockSize,
       refNameToId,
       firstDataLine,
+      maxBlockSize,
+      maxBinNumber,
+      maxRefLength,
     } = await this.parse()
     return {
       columnNumbers,
@@ -95,10 +97,12 @@ class CSI {
       format,
       coordinateType,
       skipLines,
-      maxBlockSize,
       refIdToName,
       refNameToId,
       firstDataLine,
+      maxBlockSize,
+      maxBinNumber,
+      maxRefLength,
     }
   }
 
@@ -170,6 +174,8 @@ class CSI {
     data.minShift = bytes.readInt32LE(4)
     data.depth = bytes.readInt32LE(8)
     data.maxBinNumber = ((1 << ((data.depth + 1) * 3)) - 1) / 7
+    data.maxRefLength = 2 ** (data.minShift + data.depth * 3)
+
     const auxLength = bytes.readInt32LE(12)
     if (auxLength) {
       Object.assign(data, this.parseAuxData(bytes, 16, auxLength))

--- a/src/tabixIndexedFile.js
+++ b/src/tabixIndexedFile.js
@@ -91,14 +91,17 @@ class TabixIndexedFile {
     if (refName === undefined)
       throw new TypeError('must provide a reference sequence name')
     if (!lineCallback) throw new TypeError('line callback must be provided')
+
+    const metadata = await this.index.getMetadata()
+    if (!start) start = 0
+    if (!end) end = metadata.maxRefLength
     if (!(start <= end))
       throw new TypeError(
-        'invalid start and end coordinates. must be provided, and start must be less than or equal to end',
+        'invalid start and end coordinates. start must be less than or equal to end',
       )
-    else if (start === end) return
+    if (start === end) return
 
     const chunks = await this.index.blocksForRange(refName, start, end)
-    const metadata = await this.index.getMetadata()
 
     // check the chunks for any that are over the size limit.  if
     // any are, don't fetch any of them

--- a/src/tbi.js
+++ b/src/tbi.js
@@ -62,6 +62,8 @@ class TabixIndex {
       refNameToId,
       firstDataLine,
       maxBlockSize,
+      maxBinNumber,
+      maxRefLength,
     } = await this.parse()
     return {
       columnNumbers,
@@ -73,7 +75,8 @@ class TabixIndex {
       refNameToId,
       firstDataLine,
       maxBlockSize,
-      maxBinNumber: ((1 << 18) - 1) / 7,
+      maxBinNumber,
+      maxRefLength,
     }
   }
 
@@ -105,6 +108,7 @@ class TabixIndex {
     data.metaValue = bytes.readInt32LE(24)
     data.depth = 5
     data.maxBinNumber = ((1 << ((data.depth + 1) * 3)) - 1) / 7
+    data.maxRefLength = 2 ** (14 + data.depth * 3)
     data.metaChar = data.metaValue ? String.fromCharCode(data.metaValue) : null
     data.skipLines = bytes.readInt32LE(28)
 

--- a/test/csi.test.js
+++ b/test/csi.test.js
@@ -31,6 +31,8 @@ describe('csi index', () => {
       refNameToId: { 1: 0, ctgB: 1 },
       skipLines: 0,
       maxBlockSize: 1 << 16,
+      maxBinNumber: 299593,
+      maxRefLength: 4294967296,
     })
   })
   it('loads test.vcf.gz.csi', async () => {
@@ -63,6 +65,8 @@ describe('csi index', () => {
       refNameToId: { 1: 0 },
       maxBlockSize: 1 << 16,
       skipLines: 0,
+      maxBinNumber: 299593,
+      maxRefLength: 4294967296,
     })
   })
 })

--- a/test/tabixindexedfile.test.js
+++ b/test/tabixindexedfile.test.js
@@ -79,6 +79,42 @@ describe('tabix file', () => {
       refNameToId: { ctgA: 0 },
       skipLines: 0,
       maxBinNumber: 37449,
+      maxRefLength: 536870912,
+    })
+  })
+  it('can read ctgA:10000', async () => {
+    const f = new TabixIndexedFile({
+      path: require.resolve('./data/volvox.test.vcf.gz'),
+      tbiPath: require.resolve('./data/volvox.test.vcf.gz.tbi'),
+      yieldLimit: 10,
+      renameRefSeqs: n => n.replace('contig', 'ctg'),
+    })
+    const items = new RecordCollector()
+    await f.getLines('ctgA', 10000, undefined, items.callback)
+    items.expectNoDuplicates()
+    expect(items.length).toEqual(30)
+    items.forEach(({ line, fileOffset }) => {
+      line = line.split('\t')
+      expect(line[0]).toEqual('contigA')
+      expect(parseInt(line[1], 10)).toBeGreaterThan(9999)
+      expect(fileOffset).toBeGreaterThanOrEqual(0)
+    })
+  })
+  it('can read ctgA', async () => {
+    const f = new TabixIndexedFile({
+      path: require.resolve('./data/volvox.test.vcf.gz'),
+      tbiPath: require.resolve('./data/volvox.test.vcf.gz.tbi'),
+      yieldLimit: 10,
+      renameRefSeqs: n => n.replace('contig', 'ctg'),
+    })
+    const items = new RecordCollector()
+    await f.getLines('ctgA', undefined, undefined, items.callback)
+    items.expectNoDuplicates()
+    expect(items.length).toEqual(109)
+    items.forEach(({ line, fileOffset }) => {
+      line = line.split('\t')
+      expect(line[0]).toEqual('contigA')
+      expect(fileOffset).toBeGreaterThanOrEqual(0)
     })
   })
   it('can count lines with TBI', async () => {

--- a/test/tbi.test.js
+++ b/test/tbi.test.js
@@ -32,6 +32,7 @@ describe('tbi index', () => {
       refNameToId: { contigA: 0 },
       maxBlockSize: 1 << 16,
       skipLines: 0,
+      maxRefLength: 536870912,
     })
     console.warn = jest.fn()
     expect(await ti.blocksForRange('contigA', 7334998796, 8104229566)).toEqual(


### PR DESCRIPTION
Adds the ability to leave `end` out of the `getLines` query and get all lines starting with `start` for that refName, like:

```js
const lines = []
await tbiIndexed.getLines('ctgA', 200, undefined, (line, fileOffset) => lines.push(line))
```

Does this by adding a max possible reference sequence length to the metadata and assuming `end` is that max length if it is omitted.

resolves #24 