### PR TITLE
Add fix similar to @gmod/bam #36

### DIFF
--- a/src/csi.js
+++ b/src/csi.js
@@ -280,21 +280,6 @@ class CSI {
 
     off = off.sort((a, b) => a.compareTo(b))
 
-    // resolve completely contained adjacent blocks
-    l = 0
-    for (let i = 1; i < numOffsets; i += 1) {
-      if (off[l].maxv.compareTo(off[i].maxv) < 0) {
-        l += 1
-        off[l].minv = off[i].minv
-        off[l].maxv = off[i].maxv
-      }
-    }
-    numOffsets = l + 1
-
-    // resolve overlaps between adjacent blocks; this may happen due to the merge in indexing
-    for (let i = 1; i < numOffsets; i += 1)
-      if (off[i - 1].maxv.compareTo(off[i].minv) >= 0)
-        off[i - 1].maxv = off[i].minv
     // merge adjacent blocks
     l = 0
     for (let i = 1; i < numOffsets; i += 1) {

--- a/src/tbi.js
+++ b/src/tbi.js
@@ -259,21 +259,6 @@ class TabixIndex {
 
     off = off.sort((a, b) => a.compareTo(b))
 
-    // resolve completely contained adjacent blocks
-    l = 0
-    for (let i = 1; i < numOffsets; i += 1) {
-      if (off[l].maxv.compareTo(off[i].maxv) < 0) {
-        l += 1
-        off[l].minv = off[i].minv
-        off[l].maxv = off[i].maxv
-      }
-    }
-    numOffsets = l + 1
-
-    // resolve overlaps between adjacent blocks; this may happen due to the merge in indexing
-    for (let i = 1; i < numOffsets; i += 1)
-      if (off[i - 1].maxv.compareTo(off[i].minv) >= 0)
-        off[i - 1].maxv = off[i].minv
     // merge adjacent blocks
     l = 0
     for (let i = 1; i < numOffsets; i += 1) {


### PR DESCRIPTION
This gets rid of "block merging"

This change appeared to me to reduce the incidence of "precomputed feature vcf-1234567787" not found on the chm vcf track in hg19 on jbrowse2