### PR TITLE
Remove fileoffset checks

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,20 @@
+# EditorConfig helps developers define and maintain consistent
+# coding styles between different editors and IDEs
+# editorconfig.org
+
+root = true
+
+[*]
+
+# Change these settings to your own preference
+indent_style = space
+indent_size = 2
+
+# We recommend you to keep these unchanged
+end_of_line = lf
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = true
+
+[*.md]
+trim_trailing_whitespace = false

--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ coverage/
 test/data/extended/
 *.uncompressed
 test/extended_data
+.eslintcache

--- a/README.md
+++ b/README.md
@@ -34,18 +34,18 @@ const remoteTbiIndexed = new TabixIndexedFile({
 
 // iterate over lines in the specified region
 const lines = []
-await tbiIndexed.getLines('ctgA',200,300, (line, fileOffset) => lines.push(line))
+await tbiIndexed.getLines('ctgA',200,300, (line, lineHash) => lines.push(line))
 // alternative API usage
 const aborter = new AbortController()
 await tbiIndexed.getLines('ctgA',200,300, {
-  lineCallback: (line, fileOffset) => lines.push(line),
+  lineCallback: (line, lineHash) => lines.push(line),
   signal: aborter.signal // an optional AbortSignal from an AbortController
 })
 // lines is now an array of strings, which are data lines.
 // commented (meta) lines are skipped.
 // line strings do not include any trailing whitespace characters.
-// the callback is also called with a `fileOffset`,
-// which gives the virtual file offset where the line is found in the file
+// the callback is also called with a `lineHash`,
+// which gives a lineHash to use as a feature ID
 
 // get the approximate number of data lines in the
 // file for the given reference sequence, excluding header, comment, and whitespace lines

--- a/README.md
+++ b/README.md
@@ -34,18 +34,16 @@ const remoteTbiIndexed = new TabixIndexedFile({
 
 // iterate over lines in the specified region
 const lines = []
-await tbiIndexed.getLines('ctgA',200,300, (line, lineHash) => lines.push(line))
+await tbiIndexed.getLines('ctgA',200,300, (line) => lines.push(line))
 // alternative API usage
 const aborter = new AbortController()
 await tbiIndexed.getLines('ctgA',200,300, {
-  lineCallback: (line, lineHash) => lines.push(line),
+  lineCallback: (line) => lines.push(line),
   signal: aborter.signal // an optional AbortSignal from an AbortController
 })
 // lines is now an array of strings, which are data lines.
 // commented (meta) lines are skipped.
 // line strings do not include any trailing whitespace characters.
-// the callback is also called with a `lineHash`,
-// which gives a lineHash to use as a feature ID
 
 // get the approximate number of data lines in the
 // file for the given reference sequence, excluding header, comment, and whitespace lines

--- a/package.json
+++ b/package.json
@@ -44,7 +44,6 @@
   "dependencies": {
     "@babel/runtime-corejs2": "^7.3.1",
     "abortable-promise-cache": "^1.0.1",
-    "buffer-crc32": "^0.2.13",
     "es6-promisify": "^6.0.1",
     "generic-filehandle": "^2.0.0",
     "long": "^4.0.0",
@@ -59,6 +58,7 @@
     "@babel/preset-flow": "^7.0.0",
     "babel-eslint": "^10.0.1",
     "babel-jest": "^24.1.0",
+    "buffer-crc32": "^0.2.13",
     "documentation": "^9.1.1",
     "eslint": "^5.12.0",
     "eslint-config-airbnb-base": "^13.1.0",

--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
   "dependencies": {
     "@babel/runtime-corejs2": "^7.3.1",
     "abortable-promise-cache": "^1.0.1",
+    "buffer-crc32": "^0.2.13",
     "es6-promisify": "^6.0.1",
     "generic-filehandle": "^2.0.0",
     "long": "^4.0.0",

--- a/src/tabixIndexedFile.js
+++ b/src/tabixIndexedFile.js
@@ -1,5 +1,4 @@
 import AbortablePromiseCache from 'abortable-promise-cache'
-import crc32 from 'buffer-crc32'
 
 const LRU = require('quick-lru')
 const { LocalFile } = require('generic-filehandle')

--- a/src/tabixIndexedFile.js
+++ b/src/tabixIndexedFile.js
@@ -91,7 +91,7 @@ class TabixIndexedFile {
    * @param {string} refName name of the reference sequence
    * @param {number} start start of the region (in 0-based half-open coordinates)
    * @param {number} end end of the region (in 0-based half-open coordinates)
-   * @param {function|object} lineCallback callback called for each line in the region, called as (line, lineHash) or object containing obj.lineCallback, obj.signal, etc
+   * @param {function|object} lineCallback callback called for each line in the region. can also pass a object param containing obj.lineCallback, obj.signal, etc
    * @returns {Promise} resolved when the whole read is finished, rejected on error
    */
   async getLines(refName, start, end, opts) {
@@ -143,7 +143,6 @@ class TabixIndexedFile {
 
       for (let i = 0; i < lines.length; i += 1) {
         const line = lines[i]
-        const lineHash = crc32.unsigned(line)
         // filter the line for whether it is within the requested range
         const { startCoordinate, overlaps } = this.checkLine(
           metadata,
@@ -161,7 +160,7 @@ class TabixIndexedFile {
         previousStartCoordinate = startCoordinate
 
         if (overlaps) {
-          lineCallback(line.trim(), lineHash)
+          lineCallback(line.trim())
         } else if (startCoordinate >= end) {
           // the lines were overlapping the region, but now have stopped, so
           // we must be at the end of the relevant data and we can stop

--- a/test/tabixindexedfile.test.js
+++ b/test/tabixindexedfile.test.js
@@ -1,4 +1,3 @@
-const { LocalFile } = require('generic-filehandle')
 const TabixIndexedFile = require('../src/tabixIndexedFile')
 const VirtualOffset = require('../src/virtualOffset')
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1614,6 +1614,11 @@ bser@^2.0.0:
   dependencies:
     node-int64 "^0.4.0"
 
+buffer-crc32@^0.2.13:
+  version "0.2.13"
+  resolved "https://registry.yarnpkg.com/buffer-crc32/-/buffer-crc32-0.2.13.tgz#0d333e3f00eac50aa1454abd30ef8c2a5d9a7242"
+  integrity sha1-DTM+PwDqxQqhRUq9MO+MKl2ackI=
+
 buffer-equal@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/buffer-equal/-/buffer-equal-1.0.0.tgz#59616b498304d556abd466966b22eeda3eca5fbe"


### PR DESCRIPTION
This removes fileOffset notions following implosion of the bam-js debacle 

https://github.com/GMOD/bam-js/issues/43
https://github.com/GMOD/bam-js/pull/36

These issues put together suggest that the fileOffset concept was basically flawed and so this restores lineHash

Potentially, if desirable, lineHash could be removed if a consumer would not care about it, and be done in a client library, but it seems useful as a drop in to keep the crc32 unique id