### PR TITLE
Use returned buffer from read()

### DIFF
--- a/src/tabixIndexedFile.js
+++ b/src/tabixIndexedFile.js
@@ -374,17 +374,15 @@ class TabixIndexedFile {
     if (position + compressedSize > fileSize)
       compressedSize = fileSize - position
 
-    const compressedData = Buffer.alloc(compressedSize)
-
-    /* const bytesRead = */ await this.filehandle.read(
-      compressedData,
+    const { buffer } = await this.filehandle.read(
+      Buffer.alloc(compressedSize),
       0,
       compressedSize,
       position,
       opts,
     )
 
-    return compressedData
+    return buffer
   }
 
   /**


### PR DESCRIPTION
Same idea as https://github.com/GMOD/bam-js/pull/42: Use the buffer returned from `read()` instead of the one that got passed in.