### PR TITLE
Remove usage of size() 

### DIFF
--- a/src/tabixIndexedFile.ts
+++ b/src/tabixIndexedFile.ts
@@ -454,10 +454,6 @@ export default class TabixIndexedFile {
     compressedSize: number,
     opts: Options = {},
   ) {
-    const { size: fileSize } = await this.filehandle.stat()
-    if (position + compressedSize > fileSize)
-      compressedSize = fileSize - position
-
     const { buffer } = await this.filehandle.read(
       Buffer.alloc(compressedSize),
       0,


### PR DESCRIPTION
The usage of size() in this library to guard against possibly over-reading the end of the file seems like a unnecessary precaution that results users requiring a more complex CORS config e.g. exposing content-range which seems somewhat atypical for CORS configs

I think that size() is precautionary and anything that fetched past the end of the file would imply a corrupt index so our code wouldn't really help the fact that the index is corrupt and therefore, can probably be removed