### PR TITLE
Use TextDecoder and yield based on time instead of number of lines

### DIFF
--- a/src/tabixIndexedFile.ts
+++ b/src/tabixIndexedFile.ts
@@ -162,8 +162,11 @@ export default class TabixIndexedFile {
         c,
         signal,
       )
-      const decoder = new TextDecoder('utf-8')
-      const lines = decoder.decode(buffer.buffer).split('\n')
+
+      const lines = TextDecoder
+        ? new TextDecoder('utf-8').decode(buffer.buffer).split('\n')
+        : buffer.toString()
+
       lines.pop()
       checkAbortSignal(signal)
       let blockStart = c.minv.dataPosition

--- a/src/tabixIndexedFile.ts
+++ b/src/tabixIndexedFile.ts
@@ -2,9 +2,14 @@ import AbortablePromiseCache from 'abortable-promise-cache'
 import LRU from 'quick-lru'
 import { GenericFilehandle, LocalFile } from 'generic-filehandle'
 import { unzip, unzipChunkSlice } from '@gmod/bgzf-filehandle'
-
 import { checkAbortSignal } from './util'
 import IndexFile, { Options } from './indexFile'
+
+const perf =
+  typeof performance !== 'undefined'
+    ? performance
+    : require('perf_hooks').performance
+
 import Chunk from './chunk'
 import TBI from './tbi'
 import CSI from './csi'
@@ -14,12 +19,10 @@ function timeout(time: number) {
     setTimeout(resolve, time)
   })
 }
-
 export default class TabixIndexedFile {
   private filehandle: GenericFilehandle
   private index: IndexFile
   private renameRefSeq: (n: string) => string
-  private yieldLimit: number
   private chunkCache: any
   /**
    * @param {object} args
@@ -30,7 +33,6 @@ export default class TabixIndexedFile {
    * @param {string} [args.csiPath]
    * @param {filehandle} [args.csiFilehandle]
    * default 2MiB
-   * @param {number} [args.yieldLimit] maximum number of lines to parse without yielding.
    * this avoids having a large read prevent any other work getting done on the thread.  default 300 lines.
    * @param {function} [args.renameRefSeqs] optional function with sig `string => string` to transform
    * reference sequence names for the purpose of indexing and querying. note that the data that is returned is
@@ -45,7 +47,6 @@ export default class TabixIndexedFile {
     tbiFilehandle,
     csiPath,
     csiFilehandle,
-    yieldLimit = 300,
     renameRefSeqs = n => n,
     chunkCacheSize = 5 * 2 ** 20,
   }: {
@@ -55,7 +56,6 @@ export default class TabixIndexedFile {
     tbiFilehandle?: GenericFilehandle
     csiPath?: string
     csiFilehandle?: GenericFilehandle
-    yieldLimit?: number
     renameRefSeqs?: (n: string) => string
     chunkCacheSize?: number
   }) {
@@ -94,7 +94,6 @@ export default class TabixIndexedFile {
       )
     }
 
-    this.yieldLimit = yieldLimit
     this.renameRefSeq = renameRefSeqs
     this.chunkCache = new AbortablePromiseCache({
       cache: new LRU({
@@ -153,7 +152,7 @@ export default class TabixIndexedFile {
     checkAbortSignal(signal)
 
     // now go through each chunk and parse and filter the lines out of it
-    let last = performance.now()
+    let last = perf.now()
     for (let chunkNum = 0; chunkNum < chunks.length; chunkNum += 1) {
       let previousStartCoordinate: number | undefined
       const c = chunks[chunkNum]
@@ -163,11 +162,12 @@ export default class TabixIndexedFile {
         signal,
       )
 
-      const lines = TextDecoder
-        ? new TextDecoder('utf-8').decode(buffer.buffer).split('\n')
+      const lines = (typeof TextDecoder !== 'undefined'
+        ? new TextDecoder('utf-8').decode(buffer)
         : buffer.toString()
-
+      ).split('\n')
       lines.pop()
+
       checkAbortSignal(signal)
       let blockStart = c.minv.dataPosition
       let pos
@@ -219,8 +219,8 @@ export default class TabixIndexedFile {
         blockStart += line.length + 1
 
         // yield if we have emitted beyond the yield limit
-        if (last - performance.now() > 10000) {
-          last = performance.now()
+        if (last - perf.now() > 10000) {
+          last = perf.now()
           await timeout(1)
         }
       }

--- a/src/tabixIndexedFile.ts
+++ b/src/tabixIndexedFile.ts
@@ -218,6 +218,7 @@ export default class TabixIndexedFile {
         // yield if we have emitted beyond the yield limit
         if (last - perf.now() > 500) {
           last = perf.now()
+          checkAbortSignal(signal)
           await timeout(1)
         }
       }

--- a/src/tabixIndexedFile.ts
+++ b/src/tabixIndexedFile.ts
@@ -28,8 +28,7 @@ export default class TabixIndexedFile {
    * @param {filehandle} [args.tbiFilehandle]
    * @param {string} [args.csiPath]
    * @param {filehandle} [args.csiFilehandle]
-   * default 2MiB
-   * this avoids having a large read prevent any other work getting done on the thread.  default 300 lines.
+   * @param {chunkSizeLimit} default 50MiB
    * @param {function} [args.renameRefSeqs] optional function with sig `string => string` to transform
    * reference sequence names for the purpose of indexing and querying. note that the data that is returned is
    * not altered, just the names of the reference sequences that are used for querying.

--- a/src/tabixIndexedFile.ts
+++ b/src/tabixIndexedFile.ts
@@ -216,7 +216,7 @@ export default class TabixIndexedFile {
         blockStart += line.length + 1
 
         // yield if we have emitted beyond the yield limit
-        if (last - perf.now() > 10000) {
+        if (last - perf.now() > 500) {
           last = perf.now()
           await timeout(1)
         }

--- a/src/tabixIndexedFile.ts
+++ b/src/tabixIndexedFile.ts
@@ -5,10 +5,7 @@ import { unzip, unzipChunkSlice } from '@gmod/bgzf-filehandle'
 import { checkAbortSignal } from './util'
 import IndexFile, { Options } from './indexFile'
 
-const perf =
-  typeof performance !== 'undefined'
-    ? performance
-    : require('perf_hooks').performance
+const perf = typeof performance !== 'undefined' ? performance : Date
 
 import Chunk from './chunk'
 import TBI from './tbi'

--- a/src/tabixIndexedFile.ts
+++ b/src/tabixIndexedFile.ts
@@ -153,7 +153,7 @@ export default class TabixIndexedFile {
     checkAbortSignal(signal)
 
     // now go through each chunk and parse and filter the lines out of it
-    const linesSinceLastYield = 0
+    let last = performance.now()
     for (let chunkNum = 0; chunkNum < chunks.length; chunkNum += 1) {
       let previousStartCoordinate: number | undefined
       const c = chunks[chunkNum]
@@ -219,12 +219,10 @@ export default class TabixIndexedFile {
         blockStart += line.length + 1
 
         // yield if we have emitted beyond the yield limit
-        // linesSinceLastYield += 1
-        // if (linesSinceLastYield >= this.yieldLimit) {
-        //   await timeout(1)
-        //   checkAbortSignal(signal)
-        //   linesSinceLastYield = 0
-        // }
+        if (last - performance.now() > 10000) {
+          last = performance.now()
+          await timeout(1)
+        }
       }
     }
   }

--- a/src/tabixIndexedFile.ts
+++ b/src/tabixIndexedFile.ts
@@ -153,7 +153,7 @@ export default class TabixIndexedFile {
     checkAbortSignal(signal)
 
     // now go through each chunk and parse and filter the lines out of it
-    let linesSinceLastYield = 0
+    const linesSinceLastYield = 0
     for (let chunkNum = 0; chunkNum < chunks.length; chunkNum += 1) {
       let previousStartCoordinate: number | undefined
       const c = chunks[chunkNum]
@@ -162,7 +162,8 @@ export default class TabixIndexedFile {
         c,
         signal,
       )
-      const lines = buffer.toString('ascii').split('\n')
+      const decoder = new TextDecoder('utf-8')
+      const lines = decoder.decode(buffer.buffer).split('\n')
       lines.pop()
       checkAbortSignal(signal)
       let blockStart = c.minv.dataPosition
@@ -215,12 +216,12 @@ export default class TabixIndexedFile {
         blockStart += line.length + 1
 
         // yield if we have emitted beyond the yield limit
-        linesSinceLastYield += 1
-        if (linesSinceLastYield >= this.yieldLimit) {
-          await timeout(1)
-          checkAbortSignal(signal)
-          linesSinceLastYield = 0
-        }
+        // linesSinceLastYield += 1
+        // if (linesSinceLastYield >= this.yieldLimit) {
+        //   await timeout(1)
+        //   checkAbortSignal(signal)
+        //   linesSinceLastYield = 0
+        // }
       }
     }
   }


### PR DESCRIPTION
I was testing some raw tabix parsing performance and saw a couple things, the use case was to parse an entire chromosome up front


Some notes

1) This results in large chunk sizes. We can look into this but I think removing chunkSizeLimit should be done. This is basically an internal condition but it has been constantly exposed to end users and causes frustration
2) buffer.toString(), which is a browserified nodejs buffer, results in a ton of "GC pressure" (see screenshot 1), but changing to TextDecoder(buffer.buffer) results in no GC pressure and is much faster, this is on 11MB of data gzipped, 45MB unpacked in memory buffer, coverted to string
3) The yield while parsing also results in slowdowns when we are interested in raw performance. I don't know the best answer but instead of a number of features timeout it could be a timer based yield


These are small things but when parsing whole-genome datasets like we are these days it makes a difference

This is chr20 only data used for testing


Before change:
![Screenshot from 2020-08-06 12-42-46](https://user-images.githubusercontent.com/6511937/89559101-31b95900-d7e3-11ea-890d-76e29ae7b273.png)

After change
![Screenshot from 2020-08-06 12-40-38](https://user-images.githubusercontent.com/6511937/89559140-4138a200-d7e3-11ea-9825-8ed323934d57.png)


This achieves 2x performance improvement (12s vs 6s)